### PR TITLE
Fixed a small bug in share.html.

### DIFF
--- a/_includes/share.html
+++ b/_includes/share.html
@@ -1,4 +1,4 @@
-<a class="twitter" href="https://twitter.com/intent/tweet?text={{ site.baseurl }}{{ page.url }} - {{page.title}} by @{{ site.authorTwitter }}"><span class="icon-twitter"> Tweet</span></a>
+<a class="twitter" href="https://twitter.com/intent/tweet?text={{ site.domain_name }}{{ page.url }} - {{page.title}} by @{{ site.authorTwitter }}"><span class="icon-twitter"> Tweet</span></a>
 
 <a class="facebook" href="#" onclick="
     window.open(


### PR DESCRIPTION
Before:
"/page.url" was shared on twitter, which seemed useless to me."
Now:
"domain_name/page.url" is shared on twitter, which redirects the user to the post page."

![before](https://cloud.githubusercontent.com/assets/6371303/8893370/42a0e792-33ab-11e5-8241-99f988f3b9f4.png)

![after](https://cloud.githubusercontent.com/assets/6371303/8893371/42a0d388-33ab-11e5-9a95-3fe553bc901b.png)
