### PR TITLE
Updated the disqus include with new embed js

### DIFF
--- a/_includes/disqus.html
+++ b/_includes/disqus.html
@@ -1,14 +1,16 @@
 <section class="disqus">
     <div id="disqus_thread"></div>
-    <script type="text/javascript">
-        var disqus_shortname = '{{ site.disqus_shortname }}';
-        var disqus_developer = 0; // developer mode is on
-        (function() {
-            var dsq = document.createElement('script'); dsq.type = 'text/javascript'; dsq.async = true;
-            dsq.src = '//' + disqus_shortname + '.disqus.com/embed.js';
-            (document.getElementsByTagName('head')[0] || document.getElementsByTagName('body')[0]).appendChild(dsq);
+    <script>
+        var disqus_config = function () {
+            this.page.url = '{{site.url}}{{page.url}}';
+            this.page.identifier = '{{page.id}}';
+        };
+        (function() { // DON'T EDIT BELOW THIS LINE
+            var d = document, s = d.createElement('script');
+            s.src = '//{{ site.disqus_shortname }}.disqus.com/embed.js';
+            s.setAttribute('data-timestamp', +new Date());
+            (d.head || d.body).appendChild(s);
         })();
     </script>
-    <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
-    <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
+    <noscript>Please enable JavaScript to view the <a href="https://disqus.com/?ref_noscript" rel="nofollow">comments powered by Disqus.</a></noscript>
 </section>


### PR DESCRIPTION
Hi,

When starting to use your cactus template for jekyll, I noticed that disqus seemingly updated the embed code snippet.

It seems to feature improvements related to so called "[configuration variables](https://help.disqus.com/customer/portal/articles/472098-javascript-configuration-variables)" which seem quite useful.
