### PR TITLE
Navigation and emoji images bugs

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -1,5 +1,5 @@
 <nav class="main-nav">
-    {% if page.url != "/index.html" %}
+    {% if page.url != "/index.html" and page.url != "/" %}
         <a href="{{ site.baseurl }}"> <span class="arrow">←</span> Home </a>
     {% endif %}
 

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -352,7 +352,7 @@ thead th,th {
 	white-space: nowrap;
 }
 
-img {
+img:not(.emoji) {
 	width: 100%;
 	max-width: 100%;
 	border-radius: 3px;


### PR DESCRIPTION
Link to home is hidden only if the home page is accessed through `/index.html` but reappears in the navigation when accessed through `/`.

All images expand to 100% by default and that causes jemoji images to be displayed incorrectly.
